### PR TITLE
created python test generation module

### DIFF
--- a/specalign/cli.py
+++ b/specalign/cli.py
@@ -7,6 +7,7 @@ import click
 from specalign.commands.compile import run_compile
 from specalign.commands.evaluate import run_evaluate
 from specalign.commands.generate import run_generate
+from specalign.commands.generate_behavior import run_generate_behavior
 from specalign.commands.init import run_init
 from specalign.commands.optimize import run_optimize
 from specalign.workspace import Workspace
@@ -152,6 +153,35 @@ def generate(path: Path, model: Path, output: Path, count: int, per_spec: int, w
     """Generate synthetic test cases based on specifications."""
     workspace = Workspace(path)
     run_generate(workspace, model, output, count, per_spec, workers, examples)
+
+
+@cli.command(name="generate-behavior")
+@click.option(
+    "--path",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help="Workspace path (defaults to current directory)",
+)
+@click.option(
+    "--spec",
+    required=True,
+    help="Spec filename in .specalign/specs/, e.g. file-system-management.md",
+)
+@click.option(
+    "--output-dir",
+    required=True,
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    help="Directory to write the generated behavior test (e.g. tests/integration/tests)",
+)
+@click.option(
+    "--test-name",
+    required=True,
+    help="Basename for the generated test file, e.g. b06_file_system_locate_before_edit",
+)
+def generate_behavior(path: Path, spec: str, output_dir: Path, test_name: str):
+    """Generate a skeleton Python behavior test from a single spec."""
+    workspace = Workspace(path)
+    run_generate_behavior(workspace, spec, output_dir, test_name)
 
 
 @cli.command()

--- a/specalign/commands/generate_behavior.py
+++ b/specalign/commands/generate_behavior.py
@@ -1,0 +1,109 @@
+"""Generate Python behavior test skeletons from specalign specs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specalign.workspace import Workspace
+
+
+# Very simple template: single-quoted string, no nested triple quotes.
+TEMPLATE = """# Auto-generated behavior test from specalign spec: {spec_name}
+# Source spec path: {spec_path}
+
+from textwrap import dedent
+
+from tests.integration.base import TestResult
+from tests.integration.utils.behavior_helpers import (
+    SoftwareAgentSDKBehaviorTest,
+    append_environment_tips,
+)
+from tests.integration.behavior_utils import get_conversation_summary
+from tests.integration.utils.llm_judge import judge_agent_behavior
+
+
+SPEC_TEXT = dedent(
+    {spec_text!r}
+)
+
+INSTRUCTION_BODY = dedent(
+    {instruction_body!r}
+)
+
+INSTRUCTION = append_environment_tips(INSTRUCTION_BODY)
+
+
+class {class_name}(SoftwareAgentSDKBehaviorTest):
+    \"\"\"Auto-generated behavior test skeleton for spec: {spec_name}.\"\"\"
+
+    INSTRUCTION: str = INSTRUCTION
+
+    def verify_result(self) -> TestResult:
+        \"\"\"Default verify_result that only uses the LLM judge.
+
+        NOTE: You should replace this with concrete deterministic checks
+        (filesystem, git, terminal events, etc.) derived from SPEC_TEXT, and
+        optionally keep the judge as a qualitative layer.
+        \"\"\"
+        conversation_summary = get_conversation_summary(self.collected_events)
+        criteria = (
+            "Did the agent follow the specification '{spec_name}'?\\n"
+            "Specification (excerpt):\\n" + SPEC_TEXT[:1000]
+        )
+        judgment = judge_agent_behavior(
+            user_instruction=self.INSTRUCTION,
+            conversation_summary=conversation_summary,
+            evaluation_criteria=criteria,
+        )
+
+        if judgment.approved:
+            return TestResult(
+                success=True,
+                reason=f"Behavior approved by LLM judge: {{judgment.reasoning}}",
+            )
+
+        return TestResult(
+            success=False,
+            reason=f"Behavior rejected by LLM judge: {{judgment.reasoning}}",
+        )
+"""
+
+
+def run_generate_behavior(
+    workspace: Workspace,
+    spec_filename: str,
+    output_dir: Path,
+    test_name: str,
+) -> Path:
+    """Generate a skeleton behavior test from a single spec file."""
+    spec_path = workspace.specs_dir / spec_filename
+    if not spec_path.exists():
+        raise FileNotFoundError(f"Spec file not found: {spec_path}")
+
+    spec_text = spec_path.read_text(encoding="utf-8")
+    spec_name = spec_path.stem
+
+    # Derive a simple class name from the test_name
+    base = Path(test_name).stem
+    parts = [p for p in base.split("_") if p]
+    class_name = "".join(part.capitalize() for part in parts) + "Test"
+
+    instruction_body = (
+        f"This is an auto-generated behavior test skeleton for the spec '{spec_name}'.\\n"
+        "Please edit INSTRUCTION_BODY to describe a concrete scenario and update\\n"
+        "verify_result() with deterministic checks derived from the spec."
+    )
+
+    content = TEMPLATE.format(
+        spec_name=spec_name,
+        spec_path=str(spec_path),
+        spec_text=spec_text,
+        instruction_body=instruction_body,
+        class_name=class_name,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = Path(output_dir) / f"{test_name}.py"
+    output_path.write_text(content, encoding="utf-8")
+    return output_path
+


### PR DESCRIPTION
**What:** 
Add a generate_behavior command to specalign that reads a markdown spec from .specalign/specs/ and emits a Python b*.py behavior test skeleton.
New module generate_behavior.py provides run_generate_behavior(workspace, spec_filename, output_dir, test_name) and a simple template wired to SoftwareAgentSDKBehaviorTest.

**Why:**
Makes it easier to apply specalign specs directly to the OpenHands behavior testing framework: developers can bootstrap new behavior tests from specs, then refine INSTRUCTION_BODY and verify_result() by hand.
This is the first step toward a spec to behavior-test pipeline for real-world repos (issue #7).

**How to use:**
```
# from a repo with .specalign/ already initialized
specalign generate-behavior \
  --path . \
  --spec file-system-management.md \
  --output-dir tests/integration/tests \
  --test-name b06_file_system_locate_before_edit
```

**Testing Done:**
Ran specalign generate-behavior in software-agent-sdk with --spec file-system-management.md and confirmed it produced a valid b06_*.py file that imports and runs under tests/integration/run_infer.py after filling in the instruction/verification.